### PR TITLE
Fix document and logo links

### DIFF
--- a/.github/CI-CD-GUIDE.md
+++ b/.github/CI-CD-GUIDE.md
@@ -76,8 +76,8 @@ For full functionality, configure these repository secrets:
 Add these badges to your README:
 
 ```markdown
-[![CI](https://github.com/yourusername/prompt-alchemy/workflows/CI%20Pipeline/badge.svg)](https://github.com/yourusername/prompt-alchemy/actions)
-[![codecov](https://codecov.io/gh/yourusername/prompt-alchemy/branch/main/graph/badge.svg)](https://codecov.io/gh/yourusername/prompt-alchemy)
+[![CI](https://github.com/jonwraymond/prompt-alchemy/workflows/CI%20Pipeline/badge.svg)](https://github.com/jonwraymond/prompt-alchemy/actions)
+[![codecov](https://codecov.io/gh/jonwraymond/prompt-alchemy/branch/main/graph/badge.svg)](https://codecov.io/gh/jonwraymond/prompt-alchemy)
 ```
 
 ## Dependabot Configuration (`.github/dependabot.yml`)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/prompt-alchemy-logo.png" alt="Prompt Alchemy" width="300"/>
+  <img src="docs/assets/prompt_alchemy.png" alt="Prompt Alchemy" width="300"/>
 </p>
 
 <h1 align="center">Prompt Alchemy</h1>
@@ -208,7 +208,7 @@ Each phase can be powered by different AI providers, creating a unique alchemica
 
 ## Architecture
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for a detailed overview of the alchemical laboratory.
+See [ARCHITECTURE.md](docs/architecture.md) for a detailed overview of the alchemical laboratory.
 
 ## Contributing
 


### PR DESCRIPTION
Fix broken document links and logo paths in README and update CI/CD badge URLs.